### PR TITLE
Add DateTime.strftime declaration

### DIFF
--- a/src/datetype/__init__.py
+++ b/src/datetype/__init__.py
@@ -481,6 +481,9 @@ class DateTime(Protocol[_GMaybeTZDT]):
     def ctime(self) -> str:
         ...
 
+    def strftime(self, __format: str) -> str:
+        ...
+
     def isoformat(self, sep: str = ..., timespec: str = ...) -> str:
         ...
 


### PR DESCRIPTION
This declaration was missing but does exist on datetime.datetime [0].

[0] https://docs.python.org/3/library/datetime.html#datetime.datetime.strftime

Fixes issue #4 