### PR TITLE
add repo and doc links to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ license = {file = "LICENSE.txt"}
 authors = [
   {name = "Glyph", email = "glyph@twistedmatrix.com" } # Optional
 ]
+urls = { Homepage = "https://github.com/glyph/DateType", Documentation = "https://datetype.readthedocs.io/en/latest/" }
+
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   # Indicate who your project is intended for


### PR DESCRIPTION
it's very frustrating when you run into an interesting package on PyPI and you can't go the github page 🙂 
And finding the Github repo from just the PyPI name is uneasy 